### PR TITLE
fix: unescaped mrkdwn and broken link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "termios",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "cookie"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +325,12 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -321,6 +347,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "chrono-humanize",
+ "insta",
  "jsonwebtoken",
  "reqwest",
  "rocket",
@@ -644,6 +671,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863bf97e7130bf788f29a99bc4073735af6b8ecc3da6a39c23b3a688d2d3109a"
+dependencies = [
+ "console",
+ "difference",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +749,12 @@ name = "libc"
 version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
 name = "log"
@@ -1388,6 +1435,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1592,25 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1917,6 +1995,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = "0.0.11"
 jsonwebtoken = "7.1.2"
 structopt = "0.3.15"
+
+[dev-dependencies]
+insta = "1.3.0"

--- a/src/http.rs
+++ b/src/http.rs
@@ -43,6 +43,7 @@ fn heroku_deploy_hook(
             slack_oauth_token: &config.slack_oauth_token,
             heroku_release: &task.release,
             heroku_app_name: &task.app,
+            now: chrono::Utc::now().into(),
         },
     )?)
 }

--- a/src/snapshots/eve__test__escaping_slack_messages.snap
+++ b/src/snapshots/eve__test__escaping_slack_messages.snap
@@ -1,0 +1,35 @@
+---
+source: src/lib.rs
+expression: "serde_json::to_string_pretty(&res).unwrap()"
+---
+[
+  {
+    "text": {
+      "text": "Your changes have been released to <https://dashboard.heroku.com/apps/|``> on Heroku.",
+      "type": "mrkdwn"
+    },
+    "type": "section"
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "text": {
+      "text": "<https://example.org|Fix &lt;Foo/&gt; &amp; some other thing> `56b5150`\nghost committed 4 years ago",
+      "type": "mrkdwn"
+    },
+    "type": "section"
+  },
+  {
+    "type": "divider"
+  },
+  {
+    "elements": [
+      {
+        "text": "<https://github.com/repos/ghost/repo/compare/7c68a71a87d12cc2404aed192840674af84f3df4...master|Compare diff> | <https://dashboard.heroku.com/apps//activity/releases/heroku-release-id|Release log> | <https://dashboard.heroku.com/apps/|Release activity> | heroku-release-id",
+        "type": "mrkdwn"
+      }
+    ],
+    "type": "context"
+  }
+]


### PR DESCRIPTION
Need to escape the PR titles, see https://api.slack.com/reference/surfaces/formatting#escaping

Also fixed a typo in the release env link.