### PR TITLE
fix(slack): missing fallback text for notifications

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -17,7 +17,11 @@ pub fn chat_post_message(token: &str, channel: &str, blocks: Value) -> Result<()
     let res = client
         .post("https://slack.com/api/chat.postMessage")
         .bearer_auth(token)
-        .json(&json!({"channel":channel, "blocks":blocks}))
+        .json(&json!({
+            "channel": channel,
+            "text": "Your changes have been deployed.",
+            "blocks": blocks
+        }))
         .send()?;
     res.error_for_status_ref()?;
     Ok(())


### PR DESCRIPTION
Slack will fallback to using the `text` field for notifications when it
can't display the blocks.

Without the text we get a notification that looks as follows:

<img width="382" alt="Screen Shot 2020-12-21 at 10 05 33 AM" src="https://user-images.githubusercontent.com/7340772/102835657-521a3680-43c5-11eb-852e-c8496c7ff989.png">
